### PR TITLE
FPSの低下をなくすためのMeshを非表示にするシェーダを追加

### DIFF
--- a/Assets/Project/Materials/Invisible.mat
+++ b/Assets/Project/Materials/Invisible.mat
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Invisible
+  m_Shader: {fileID: 4800000, guid: 659cd075e630ec44f82378e519de964e, type: 3}
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs: []
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 0
+    m_Colors: []
+  m_BuildTextureStacks: []

--- a/Assets/Project/Materials/Invisible.mat.meta
+++ b/Assets/Project/Materials/Invisible.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8a7b960d2e948b9488110cc35795436d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Prefabs/NRCameraRig.prefab
+++ b/Assets/Project/Prefabs/NRCameraRig.prefab
@@ -61,7 +61,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: 8a7b960d2e948b9488110cc35795436d, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Project/Shaders/Invisible.shader
+++ b/Assets/Project/Shaders/Invisible.shader
@@ -1,0 +1,18 @@
+Shader "NrealEventSample/Invisible"
+{
+    Properties
+    {
+        _ColorMask ("Color Mask", Float) = 0
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" }
+        LOD 100
+
+        Pass
+        {
+            ColorMask [_ColorMask]
+            ZWrite Off
+        }
+    }
+}

--- a/Assets/Project/Shaders/Invisible.shader.meta
+++ b/Assets/Project/Shaders/Invisible.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 659cd075e630ec44f82378e519de964e
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# What's new?

- シーン内にパーティクルのみになると著しくFPSが落ちる問題があり、そのためのMeshを非表示にするためのシェーダを追加