### PR TITLE
速度を適用すると非アクティブのパーティクルが表示されていた問題を修正

### DIFF
--- a/Assets/Project/Scripts/ParticleSystem/ParticleSystem.cs
+++ b/Assets/Project/Scripts/ParticleSystem/ParticleSystem.cs
@@ -14,6 +14,7 @@ namespace NrealEventSample
         color = 1 << 1,
         scale = 1 << 2,
         velocity = 1 << 3,
+        active = 1 << 4,
     }
 
     public class ParticleSystem : MonoBehaviour
@@ -237,7 +238,7 @@ namespace NrealEventSample
 
                 ParticleData px = new ParticleData
                 {
-                    activateTypes = (uint)(ActivateType.targetPosition | ActivateType.color | ActivateType.velocity | ActivateType.scale),
+                    activateTypes = (uint)(ActivateType.targetPosition | ActivateType.color | ActivateType.velocity | ActivateType.scale | ActivateType.active),
                     scale = _particleScale,
                     targetPosition = p,
                     velocity = Random.insideUnitSphere * _magnification,

--- a/Assets/Project/Shaders/ParticleSystem/Particle.shader
+++ b/Assets/Project/Shaders/ParticleSystem/Particle.shader
@@ -18,7 +18,7 @@ Shader "NrealEventSample/Particle"
             #pragma fragment frag
 
             #include "UnityCG.cginc"
-            #include "Include/Particle.cginc"
+            #include "../Include/Particle.cginc"
 
             struct appdata
             {

--- a/Assets/Project/Shaders/ParticleSystem/TextParticleSystem.compute
+++ b/Assets/Project/Shaders/ParticleSystem/TextParticleSystem.compute
@@ -29,7 +29,7 @@ void Initialize(uint id : SV_DispatchThreadID)
     p.color = lerp(p.color, data.color, ((data.activateTypes >> 1) & 1));
     p.scale = lerp(p.scale, data.scale, ((data.activateTypes >> 2) & 1));
     p.velocity = lerp(p.velocity, data.velocity, ((data.activateTypes >> 3) & 1));
-    p.active = (_ParticleCount > id) ? 1 : 0;
+    p.active = (_ParticleCount > id) ? lerp(p.active, 1, (data.activateTypes >> 4 & 1)) : 0;
 
     _ParticleBuffer[id] = p;
 }


### PR DESCRIPTION
# What's new?

- `ApplyRandomVelocity` 適用時に、非アクティブなパーティクルが表示されてしまっていた問題を修正。